### PR TITLE
upgrade to zk 6.0.2, using new @AfterCompose annotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	</repositories>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<zk.version>6.0.1</zk.version>
+		<zk.version>6.0.2</zk.version>
 		<zkel.version>1.0.2</zkel.version>
 		<zkspring.version>3.1</zkspring.version>
 		<spring.version>3.0.5.RELEASE</spring.version>

--- a/src/main/java/org/zkforge/zktodo2/ui/Controller.java
+++ b/src/main/java/org/zkforge/zktodo2/ui/Controller.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.zkforge.zktodo2.Model;
 import org.zkforge.zktodo2.Reminder;
 import org.zkforge.zktodo2.ReminderService;
+import org.zkoss.bind.annotation.AfterCompose;
 import org.zkoss.bind.annotation.Command;
 import org.zkoss.bind.annotation.ContextParam;
 import org.zkoss.bind.annotation.ContextType;
@@ -58,8 +59,8 @@ public class Controller {
 		this.reminderService = reminderService;
 	}
 
-	@Init
-	public void init(@ContextParam(ContextType.VIEW) Component view){
+	@AfterCompose
+	public void afterCompose(@ContextParam(ContextType.VIEW) Component view){
 		Selectors.wireComponents(view, this, false);
 		reload();
 	}


### PR DESCRIPTION
In this branch, I set zk version to 6.0.2 and also tune the code to match the new @AfterCompose lifecycle for wiring component in a ViewModel. 
